### PR TITLE
Bundled Products, Slack Integration and Terms of Service check

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -13,7 +13,7 @@
     "twix": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/twix/-/twix-0.9.0.tgz",
-      "from": "twix@0.9.0"
+      "from": "https://registry.npmjs.org/twix/-/twix-0.9.0.tgz"
     }
   }
 }

--- a/common/common.js
+++ b/common/common.js
@@ -75,7 +75,14 @@ RentalProducts = {
     }
 
     // Sort by length of inventory variants unavailableDates array
-    let inventoryVariants = InventoryVariants.find({productId: variantId, "workflow.status": "active"}, {sort: {numberOfDatesBooked: sortDirection}}).fetch();
+    let inventoryVariants = InventoryVariants.find(
+      {
+        productId: variantId,
+        active: true,
+        "workflow.status": "active"
+      }, {
+        sort: {numberOfDatesBooked: sortDirection}
+      }).fetch();
 
     if (inventoryVariants.length > 0) {
       // if this variant has multiple inventory

--- a/server/hooks.js
+++ b/server/hooks.js
@@ -24,7 +24,8 @@ ReactionCore.MethodHooks.afterMethods({
     if (cart.items && cart.items.length > 0) {
       _.map(cart.items, function (item) {
         if (item.variants._id === variantId
-          && item.variants.functionalType === "rentalVariant" // TODO: future if item.type === rental
+          && (item.variants.functionalType === "rentalVariant"
+            || item.variants.functionalType === "bundleVariant") // TODO: future if item.type === rental
           && cart.rentalDays) {
             // TODO: update qty to verified rental qty available
           // Set price to calculated rental price;

--- a/server/methods/cart.js
+++ b/server/methods/cart.js
@@ -38,7 +38,9 @@ Meteor.methods({
     // If cart has items in it - update the price for those items
     if (cart.items && cart.items.length > 0) {
       cart.items = cart.items.reduce(function (newCart, item) {
-        if (item.variants.functionalType === "rentalVariant" // TODO: future if item.type === rental
+         // TODO: future if item.type === rental
+        if ((item.variants.functionalType === "rentalVariant"
+          || item.variants.functionalType === "bundleVariant")
           && cart.rentalDays) {
             // TODO: update qty to verified rental qty available
           // Set price to calculated rental price;

--- a/server/methods/inventoryVariants.js
+++ b/server/methods/inventoryVariants.js
@@ -165,7 +165,8 @@ Meteor.methods({
     if (inventoryVariant
       && RentalProducts.checkAvailability(inventoryVariant.unavailableDates, requestedDates)) {
       let reservedDates = InventoryVariants.findOne({
-        _id: inventoryVariant._id
+        _id: inventoryVariant._id,
+        active: true,
       }, {fields: {unavailableDates: 1}}).unavailableDates;
 
       // We take the time to insert unavailable dates in ascending date order

--- a/server/methods/rentalProducts.js
+++ b/server/methods/rentalProducts.js
@@ -47,7 +47,14 @@ Meteor.methods({
     }
 
     // Sort by length of inventory variants unavailableDates array
-    let inventoryVariants = InventoryVariants.find({productId: variantId}, {sort: {numberOfDatesBooked: sortDirection}}).fetch();
+    let inventoryVariants = InventoryVariants.find(
+      {
+        productId: variantId,
+        active: true
+      }, {sort: {
+        numberOfDatesBooked: sortDirection
+      }}
+    ).fetch();
 
     if (inventoryVariants.length > 0) {
       // if this variant has multiple inventory

--- a/server/publications.js
+++ b/server/publications.js
@@ -50,7 +50,7 @@ Meteor.publish("productReservationStatus", function (productId) {
     active: true,
     "workflow.status": "active"
   }, {
-    fields: {productId: 1, unavailableDates: 1, numberOfDatesBooked: 1, "workflow.status": 1},
+    fields: {productId: 1, unavailableDates: 1, numberOfDatesBooked: 1, active: 1, "workflow.status": 1},
     sort: {unavailableDates: -1}
   });
 });


### PR DESCRIPTION
## Feature Launch - Bundled Products, Slack Integration and Terms of Service check
### Features Launched In this Updated
- **Bundle Products** - Customer can now check out with one Product and it will behind the scenes track multople items inventory
- **Blocked ability to checkout with incompatible rental lengths**. - Example can't checkout with Demo product (6 or 12 day rentals) and Camping Rental of 5 days
- **Product Bundler Package** - Now you can create a Bundle giving it name and attirbutes, plus add existing products to that bundle
- **Waiver** - On customer checkout, you must click a checkbox before you are able to checkout
- **Slack Package** - Now you can set up slack so that it posts to a specific channel when an order is placed.
